### PR TITLE
fixed second page image bug

### DIFF
--- a/layouts/partials/single_slide.html
+++ b/layouts/partials/single_slide.html
@@ -1,6 +1,6 @@
 <figure>
     <a href="{{ .Permalink }}" title="{{ .Title }}">
-	<img src="{{ .Params.banner }}" class="pngfix wp-post-image" alt="{{ .Title }}" title="{{ .Title }}">
+	<img src="{{ .Params.banner  | absURL }}" class="pngfix wp-post-image" alt="{{ .Title }}" title="{{ .Title }}">
     </a>
 </figure>
 <article class="featured-text">


### PR DESCRIPTION
- #19 
- This bug concerns the absolute URL of the image shown in the slider