### PR TITLE
Fixed of the translation of the "read more" button

### DIFF
--- a/layouts/partials/article_list.html
+++ b/layouts/partials/article_list.html
@@ -1,8 +1,5 @@
 {{ $paginator := .Paginate (where .Data.Pages "Type" "post") }}
-{{ $readmore := "Read More" }}
-{{ if .Site.Data.l10n.articles.read_more }}
-{{ $readmore := .Site.Data.l10n.articles.read_more }}
-{{ end }}
+
 {{ range $paginator.Pages }}
 <section id="main" class="post type-post status-publish format-standard has-post-thumbnail hentry">
   <article>
@@ -25,7 +22,7 @@
     {{ partial "article_footer" . }}
     <span>
       <a class="readmore" href="{{ .Permalink }}">
-	{{ $readmore }}
+	{{ with .Site.Data.l10n.articles.read_more }}{{ . }}{{ end }}
       </a>
     </span>
     


### PR DESCRIPTION
The main page didn't display a translation for the "read more" button with lists of articles. The default value "read more" of the $readmore variable always displayed, even when the translation was explicitly specified in the data / l10n.toml file. This PR fixes this.