### PR TITLE
Links to tags/categories now respect permalink configuration

### DIFF
--- a/layouts/partials/article_footer.html
+++ b/layouts/partials/article_footer.html
@@ -19,15 +19,16 @@
       <time class="entry-date published" datetime="{{ .Date }}" itemprop="datePublished">{{ .Date.Format $date_format }}</time>
     </span>
     {{ end }}
-    
+
     {{ if isset .Params "categories" }}
     {{ $categoriesLen := len .Params.categories }}
     {{ if gt $categoriesLen 0 }}
     <span class="category">
       {{ range $k, $v := .Params.categories }}
-      {{ $url := printf "%s/%s" "categories" (. | urlize | lower) }}
-      <a class="article-category-link" href="{{ $url | absURL }}">{{ . }}</a>
+      {{ with site.GetPage (printf "/%s/%s" "categories" ($v | urlize)) }}
+      <a class="article-category-link" href="{{ .Permalink }}">{{ $v }}</a>
       {{ if lt $k (sub $categoriesLen 1) }},{{ end }}
+      {{ end }}
       {{ end }}
     </span>
     {{ end }}

--- a/layouts/partials/article_list.html
+++ b/layouts/partials/article_list.html
@@ -14,7 +14,7 @@
     {{ partial "article_header" . }}
     <div class="article-entry entry-content clearfix" itemprop="articleBody">
       <p>
-        {{ printf "%s" .Summary | markdownify }}
+        {{ .Summary }}
         <br>
       </p>
       {{ partial "share" . }}

--- a/layouts/partials/article_list.html
+++ b/layouts/partials/article_list.html
@@ -6,11 +6,11 @@
     {{ if and (isset .Params "banner") (not (eq .Params.banner "")) }}
     <figure class="post-featured-image">
       <a href="{{ .RelPermalink }}" itemprop="url">
-	<img src="{{ .Params.banner | absURL }}" class="attachment-featured size-featured wp-post-image"/>
+      <img src="{{ .Params.banner | absURL }}" class="attachment-featured size-featured wp-post-image"/>
       </a>
-    </figure> 
+    </figure>
     {{ end }}
-    
+
     {{ partial "article_header" . }}
     <div class="article-entry entry-content clearfix" itemprop="articleBody">
       <p>
@@ -23,7 +23,7 @@
     {{ if .Truncated }}
     <span>
       <a class="readmore" href="{{ .RelPermalink }}">
-	    {{ with .Site.Data.l10n.articles.read_more }}{{ . }}{{ end }}
+      {{ with .Site.Data.l10n.articles.read_more }}{{ . }}{{ end }}
       </a>
     </span>
     {{ end }}{{/* if .Truncated */}}

--- a/layouts/partials/article_list.html
+++ b/layouts/partials/article_list.html
@@ -20,12 +20,13 @@
       {{ partial "share" . }}
     </div>
     {{ partial "article_footer" . }}
+    {{ if .Truncated }}
     <span>
-      <a class="readmore" href="{{ .Permalink }}">
-	{{ with .Site.Data.l10n.articles.read_more }}{{ . }}{{ end }}
+      <a class="readmore" href="{{ .RelPermalink }}">
+	    {{ with .Site.Data.l10n.articles.read_more }}{{ . }}{{ end }}
       </a>
     </span>
-    
+    {{ end }}{{/* if .Truncated */}}
     </div>
 
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -75,5 +75,8 @@
      ga('send', 'pageview');
 
     </script>
-{{ end }}
+    {{ end }}
+    {{ range $i, $src := .Site.Params.custom_css }}
+    <link rel='stylesheet' id='custom_css_{{ $i }}'  href="{{ $src | absURL }}" type='text/css' media='all' />
+    {{ end }}
 </head>

--- a/layouts/partials/single_article.html
+++ b/layouts/partials/single_article.html
@@ -4,7 +4,7 @@
 {{ end }}
 {{ end }}
 
-    <div id="content">	
+    <div id="content">
 	<section id="post" class="post type-post status-publish format-standard has-post-thumbnail hentry">
 	    <article>
 		<div class="article-inner">
@@ -14,7 +14,7 @@
 		</div>
 		<div class="entry-content" itemprop="articleBody">
 		    {{ .Content }}
-		    <!-- -    {{ partial "share" . }}  -->	
+		    <!-- -    {{ partial "share" . }}  -->
 		</div>
 		{{ if (.Params.tags) }}
 		<div class="tags">
@@ -28,7 +28,7 @@
 		{{ end }}
 		{{ partial "prev_next_post" . }}
 	    </article>
-	    
+
 	    {{ if and (and (not (eq .Site.Params.privacy.DisqusShortname "")) (not .Params.disable_comments)) (not .Site.Params.privacy.enable) }}
 	    <section id="comments">
 		<div id="disqus_thread">
@@ -37,7 +37,7 @@
 	    </section>
 	    {{ end }}
 	</section>
-	
+
     </div><!-- #content -->
 {{ if .Site.Params.widgets }}
 {{ if (not .Params.disable_profile) | and (not .Params.disable_widgets) }}

--- a/layouts/partials/single_article.html
+++ b/layouts/partials/single_article.html
@@ -19,7 +19,10 @@
 		{{ if (.Params.tags) }}
 		<div class="tags">
 		    {{ range $k, $tag := .Params.tags }}
-		    <a href="/tags/{{ $tag | urlize }}" rel="tag">{{ $tag }}</a>&middot;
+			{{ if $k }} &middot; {{ end }}
+			{{ with site.GetPage (printf "/%s/%s" "tags" ($tag | urlize)) }}
+		    <a href="{{ .Permalink }}" rel="tag">{{ $tag }}</a>
+			{{ end }}
 		    {{ end }}
 		</div>
 		{{ end }}

--- a/layouts/partials/widgets/categories.html
+++ b/layouts/partials/widgets/categories.html
@@ -2,7 +2,7 @@
   <h3 class="widget-title">{{with .Site.Data.l10n.widgets.categories.title}}{{.}}{{end}}</h3>
   <ul>
     {{ range $name, $items := .Site.Taxonomies.categories }}
-    {{ with site.GetPage (printf "/%s/%s" "categories" $name) }}
+    {{ with site.GetPage (printf "/%s/%s" "categories" ($name | urlize)) }}
     <li class="cat-item">
       <a href="{{ .Permalink }}">{{ $name | title }}</a> ({{ len $items }})
     </li>

--- a/layouts/partials/widgets/categories.html
+++ b/layouts/partials/widgets/categories.html
@@ -2,10 +2,11 @@
   <h3 class="widget-title">{{with .Site.Data.l10n.widgets.categories.title}}{{.}}{{end}}</h3>
   <ul>
     {{ range $name, $items := .Site.Taxonomies.categories }}
+    {{ with site.GetPage (printf "/%s/%s" "categories" $name) }}
     <li class="cat-item">
-      {{ $url := printf "%s/%s" "categories" ($name | urlize)}}
-      <a href="{{ $url | absURL }}">{{ $name | title }}</a> ({{ len $items }})
+      <a href="{{ .Permalink }}">{{ $name | title }}</a> ({{ len $items }})
     </li>
+    {{ end }}
     {{ end }}
   </ul>
 </aside>

--- a/layouts/partials/widgets/tag_cloud.html
+++ b/layouts/partials/widgets/tag_cloud.html
@@ -9,10 +9,12 @@
 {{ $baseurl := .Site.BaseURL }}
 {{ range $name, $value := .Site.Taxonomies.tags }}
     {{ if (gt $value.Count $min_count) }}
-    <a href="{{ $baseurl }}tags/{{ $name | urlize }}" style="font-size: {{ add ($value.Count) $mag_factor }}px;" title="{{ ($value.Count) }} topics">
+    {{ with site.GetPage (printf "/%s/%s" "tags" $name) }}
+    <a href="{{ .Permalink }}" style="font-size: {{ add ($value.Count) $mag_factor }}px;" title="{{ ($value.Count) }} topics">
       <!--a href="{{ $baseurl }}/tags/{{ $name | urlize }}"-->
       {{ $name | title }}
     </a>
+      {{ end }}
       {{ end }}
       {{ end }}
   </div>

--- a/layouts/partials/widgets/tag_cloud.html
+++ b/layouts/partials/widgets/tag_cloud.html
@@ -9,7 +9,7 @@
 {{ $baseurl := .Site.BaseURL }}
 {{ range $name, $value := .Site.Taxonomies.tags }}
     {{ if (gt $value.Count $min_count) }}
-    {{ with site.GetPage (printf "/%s/%s" "tags" $name) }}
+    {{ with site.GetPage (printf "/%s/%s" "tags" ($name | urlize)) }}
     <a href="{{ .Permalink }}" style="font-size: {{ add ($value.Count) $mag_factor }}px;" title="{{ ($value.Count) }} topics">
       <!--a href="{{ $baseurl }}/tags/{{ $name | urlize }}"-->
       {{ $name | title }}


### PR DESCRIPTION
Blog configuration can be modified to have different link
permalink layout.

e.g. in the `[permalinks]` section, categories can be set up in these
different ways:

- `categories = "/category/:slug/"`
- `categories = "/categories/:slug/"`

The widgets for categories and tag_cloud were hardcoding the permalinks
URL. This fix will make the URL respect permalink configuration.

Inspired from this hugo forum conversation:

https://discourse.gohugo.io/t/how-to-get-permalink-of-taxonomies-in-templates/12927/15