### PR TITLE
Add missing closing bracket to script tag in footer_js

### DIFF
--- a/layouts/partials/footer_js.html
+++ b/layouts/partials/footer_js.html
@@ -13,7 +13,7 @@
 <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {{ end }}
 <script type='text/javascript' src="{{ .Site.BaseURL }}js/jquery.min.js" id='jquery-core-js'></script>
-<script type='text/javascript' src="{{ .Site.BaseURL }}js/jquery-migrate.min.js" id='jquery-migrate-js'</script>
+<script type='text/javascript' src="{{ .Site.BaseURL }}js/jquery-migrate.min.js" id='jquery-migrate-js'></script>
 <script type='text/javascript' src="{{ .Site.BaseURL }}js/functions.min.js" id='travelify_functions-js'></script>
 <!-- <script type='text/javascript' src="{{ .Site.BaseURL }}js/admin-bar.min.js"></script> -->
 <script type='text/javascript' src="{{ .Site.BaseURL }}js/jquery.cycle.all.min.js" id='jquery_cycle-js'></script>


### PR DESCRIPTION
Currently the functions.min.js script isn't loaded due to a missing closing bracket on the previous line.